### PR TITLE
build: add springdoc-openapi and security configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
 			<version>4.5.0</version>
 		</dependency>
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.0.3</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/src/main/java/com/web/ifocus/SecurityConfig.java
+++ b/src/main/java/com/web/ifocus/SecurityConfig.java
@@ -1,0 +1,18 @@
+package com.web.ifocus;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf().disable()
+            .authorizeRequests()
+                .anyRequest().permitAll();
+        return http.build();
+    }
+}


### PR DESCRIPTION
Add springdoc-openapi-starter-webmvc-ui dependency for API documentation and introduce SecurityConfig to disable CSRF and permit all requests. This enables OpenAPI documentation and ensures security configurations are in place.